### PR TITLE
Refactor JSON type check in outbound request validation

### DIFF
--- a/app/Http/Requests/Api/Bridge/OutBoundRequest.php
+++ b/app/Http/Requests/Api/Bridge/OutBoundRequest.php
@@ -58,7 +58,7 @@ class OutBoundRequest extends FormRequest
 					$type = $this->input('body.type');
 
 					if ($type === 'json') {
-						if (is_array($value) && !empty($value)) {
+						if (is_array($value)) {
 							return;
 						}
 


### PR DESCRIPTION
Removed unnecessary emptiness check for array type validation. This ensures consistency and simplifies the logic when handling 'json' typed input.